### PR TITLE
Check availability of property

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,4 +1,14 @@
 class Booking < ApplicationRecord
     belongs_to :user
     belongs_to :property
+
+    scope :overlaps_date, -> (date) { where("'#{date}' BETWEEN start_date AND end_date") }
+    scope :within_date_range, -> (start_on, end_on) do
+      where("(start_date BETWEEN '#{start_on}' AND '#{end_on}') AND end_date BETWEEN '#{start_on}' AND '#{end_on}'")
+    end
+    scope :clashes_with, -> (start_on, end_on) do
+      within_date_range(start_on, end_on)
+        .or(overlaps_date(start_on))
+        .or(overlaps_date(end_on))
+    end
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -44,20 +44,6 @@ class Property < ApplicationRecord
   end
 
   def available?(start_date, end_date)
-    window_start = self.bookings.where('end_date < ?', start_date).last
-    if (window_start)
-      if (self.bookings.where('id > ?', window_start.id).first)
-        if (self.bookings.where('id > ?', window_start.id).first.start_date > end_date.to_datetime)
-          true
-        else
-          false
-        end
-      else
-        false
-      end
-    else
-      true
-    end
+    bookings.clashes_with(start_date, end_date).none?
   end
-
 end


### PR DESCRIPTION
Turns out I'd done this logic about date ranges a few times before, but the [`BETWEEN start AND end` in Postgres](https://www.delftstack.com/howto/postgres/postgresql-query-between-date-ranges/) really helped. 

Basically, if my rough sketch diagram is correct, a booking clashes with my start and end date in the following three scenarios:

1. my start date is between the start and end of the existing booking
2. my end date is between the start and end of the existing booking
3. the existing booking starts and (could be or here, but then we get duplicates of 1 or 2) ends between the start and end dates of my booking.

I've moved this logic to the `Booking` class because that class is really responsible for querying that table, but that's not too important.. the bigger shift here is to let the SQL do the heavy lifting, and on the dates, not the ids.